### PR TITLE
Prerequisities of certmagic requires golang=<1.14

### DIFF
--- a/s3www/Dockerfile
+++ b/s3www/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine3.10
+FROM golang:1.14-alpine3.11
 
 ENV ENDPOINT http://127.0.0.1:9000
 ENV ACCESSKEY xtesting


### PR DESCRIPTION
`Error: hello.SupportsCertificate undefined (type *tls.ClientHelloInfo has no field or method SupportsCertificate)`

Closed [bugreport](https://github.com/caddyserver/xcaddy/issues/14)

### Reason
Golang dockerhub repo doesn't provide alpine3.10+golang1.14