### PR TITLE
Use JENKINS_AUTH env variable for agent registration

### DIFF
--- a/jenkins-agent-auto/auto.sh
+++ b/jenkins-agent-auto/auto.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 curl -k -fsSLo /usr/share/jenkins/jenkins-cli.jar $JENKINS_URL/jnlpJars/jenkins-cli.jar
-java -jar /usr/share/jenkins/jenkins-cli.jar -auth admin:admin -s $JENKINS_URL create-node ${JENKINS_SLAVE_NAME:-xtesting} << EOF
+java -jar /usr/share/jenkins/jenkins-cli.jar -auth ${JENKINS_AUTH} -s $JENKINS_URL create-node ${JENKINS_SLAVE_NAME:-xtesting} << EOF
 <slave><launcher class='hudson.slaves.JNLPLauncher' /><mode>NORMAL</mode><numExecutors>2</numExecutors><remoteFS>/var/jenkins_home</remoteFS></slave>
 EOF
-java -jar /usr/share/jenkins/agent.jar -jnlpUrl $JENKINS_URL/computer/${JENKINS_SLAVE_NAME:-xtesting}/slave-agent.jnlp -jnlpCredentials admin:admin
+java -jar /usr/share/jenkins/agent.jar -jnlpUrl $JENKINS_URL/computer/${JENKINS_SLAVE_NAME:-xtesting}/slave-agent.jnlp -jnlpCredentials ${JENKINS_AUTH}


### PR DESCRIPTION
When the jenkins-agent-auto container is instantiated, the following variables are passed (from the collivier.xtesting Ansible role, https://github.com/collivier/ansible-role-xtesting/blob/604a77dc5b8562469574d0ead1b9faef3b0e0a8b/tasks/jenkins.yml#L158):
* JENKINS_URL: '{{ jenkins_url }}'
* JENKINS_AUTH: '{{ jenkins_user }}:{{ jenkins_password }}'
* JENKINS_SLAVE_NAME: '{{ jenkins_agent_name }}'

The change proposed here is to **use the `JENKINS_AUTH` environment variable when the agent tries to register itself, instead of the default admin:admin credentials** which were hardcoded in the auto.sh entrypoint script.

No modification is needed from the Ansible role.